### PR TITLE
#17 pollresult.html 서브메뉴리사이즈

### DIFF
--- a/pollresult.html
+++ b/pollresult.html
@@ -86,27 +86,20 @@
 									<a name="tab">
 									<div>
 										<a href="#tab" onclick="showTab(1);">
-                                            ALL
-<!--											<img class="tab tab1 btn" src="images/pollresult/btn_1.png" srcset="images/pollresult/btn_1.png 1x, images/pollresult/btn_1@2x.png 2x"/>-->
+                                            <img class="tab tab1 btn" style="width:17%" src="images/pollresult/btn_1.png" srcset="images/pollresult/btn_1.png 1x, images/pollresult/btn_1@2x.png 2x"/>
 										</a>
-                                        /
 										<a href="#tab" onclick="showTab(2);">
-                                            NAVER
-<!--											<img class="tab tab2 btn" src="images/pollresult/btn_2.png" srcset="images/pollresult/btn_2.png 1x, images/pollresult/btn_2@2x.png 2x"/>-->
+                                            <img class="tab tab2 btn" style="width:31%" src="images/pollresult/btn_2.png" srcset="images/pollresult/btn_2.png 1x, images/pollresult/btn_2@2x.png 2x"/>
 										</a>
-                                        /
 										<a href="#tab" onclick="showTab(3);">
-                                            LINE
-<!--											<img class="tab tab3 btn" src="images/pollresult/btn_3.png" srcset="images/pollresult/btn_3.png 1x, images/pollresult/btn_3@2x.png 2x"/>-->
+											<img class="tab tab3 btn" style="width:26%" src="images/pollresult/btn_3.png" srcset="images/pollresult/btn_3.png 1x, images/pollresult/btn_3@2x.png 2x"/>
 										</a>
-                                        /
 										<a href="#tab" onclick="showTab(4);">
-                                            ETC
-<!--											<img class="tab tab4 btn" src="images/pollresult/btn_4.png" srcset="images/pollresult/btn_4.png 1x, images/pollresult/btn_4@2x.png 2x"/>-->
+											<img class="tab tab4 btn" style="width:21%" src="images/pollresult/btn_4.png" srcset="images/pollresult/btn_4.png 1x, images/pollresult/btn_4@2x.png 2x"/>
 										</a>
 									</div>
-									<img src="images/pollresult/hr.jpg" srcset="images/pollresult/hr.jpg 1x, images/pollresult/hr@2x.jpg 2x"/>
-								</div>
+									<img src="images/pollresult/hr.jpg" style="margin-top:-11px" srcset="images/pollresult/hr.jpg 1x, images/pollresult/hr@2x.jpg 2x"/>
+								</div>								
 								</header>
 
                           


### PR DESCRIPTION
#17

* 서브메뉴 이미지의 width 값을 상대값(퍼센트)로 대응되게 style를 하드코딩
* 하단 이미지의 간격이 존재하므로 간격을 수동으로 없앴습니다 

아쉬운건, 서브메뉴 이미지 버튼이 동일 width로 구성했다면, 
4개의 버튼이니 상대값을 `100% / 4 = 25%` 로 계산하면 딱 떨어지는데요.
이미지 버튼 넓이가 달라서 계산이 딱 안떨어져서 적당해 대충 계산해서 비율을 넣은건 아쉽습니다.

그리고 하단에 `hr.jpg` 의 경우도 간격이 존재해서 적당히 간격을 없애버렸습니다.


그러면 다양한 해상도에서 메뉴버튼도 이렇게 resize 되서 보이므로 행밀림은 없습니다.

![image](https://user-images.githubusercontent.com/2881314/39403184-50f54c7e-4baf-11e8-99f8-82efc3a6e2cc.png)

Ps.
사실 메뉴형태의 이미지가 resize 되는건  아무래도 안이쁘게 보일때가 생기므로 좋은방법은 아닌데
레이아웃상 `article 영역(본문)` 안에 있다보니 resize 하는게 차선책으로 보입니다. 

`@media` 속성을 이용해 css 상에서 해상도 범위에 따라 대응하는게 좋은거 같은데
그러면 웹페이지 레이아웃 전체를 다시 고민해야할 사항인것 같네요. (이건 능력자분이 해결해줄거라 믿습니다)

