### PR TITLE
anchor 위치 변경

### DIFF
--- a/pollresult.html
+++ b/pollresult.html
@@ -106,8 +106,8 @@
 								<header class="major">
 									<span class="date">April 27, 2018</span>
 								<div class="image main" style="line-height: 0">
-									<img src="images/pollresult/top.jpg" srcset="images/pollresult/top.jpg 1x, images/pollresult/top@2x.jpg 2x"/>
 									<a name="tab"> </a>
+									<img src="images/pollresult/top.jpg" srcset="images/pollresult/top.jpg 1x, images/pollresult/top@2x.jpg 2x"/>
 									<div class="tab-outter" style="width:100%;">
 										<table width="100%" align="center" valign="center">
 										<tr><td>


### PR DESCRIPTION
모바일페이지에서 anchor가 너무 아래에 있어서 플로팅버튼이 탭버튼을 가리는 문제가 있습니다.
anchor를 아래로 내림으로써 해결하였습니다.